### PR TITLE
Add basic access to SQLite database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+chat.db
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Messagediscovery
+
+Filter Mac messages based on message content.
+
+## Prep
+
+Create a local symbolic link to your Messages database.
+
+    ln -s $HOME/Library/Messages/chat.db .
+
+## Execute
+
+    ./hello.py

--- a/hello.py
+++ b/hello.py
@@ -1,3 +1,13 @@
 #!/usr/bin/env python
-print("Hello, from Messagediscovery")
+
+import sqlite3
+
+print("Hello, from Messagediscovery.")
+conn = sqlite3.connect("chat.db")
+cursor = conn.cursor()
+cursor.execute("select count(*) from message")
+rows = cursor.fetchall()
+cursor.close()
+count = rows[0][0]
+print(f"I found {count} total messages.")
 


### PR DESCRIPTION
This feature branch includes access to the Messages SQLite database, stored in chat.db.  It does not do any filtering or discovery yet, but simply displays the total number of messages in the database.